### PR TITLE
Refactor: TvSeries로 리팩토링 및 DB 설정 변경

### DIFF
--- a/src/common/enums/content-type.enum.ts
+++ b/src/common/enums/content-type.enum.ts
@@ -1,4 +1,4 @@
 export enum ContentType {
   MOVIE = 'movie',
-  TV = 'tv',
+  TVSERIES = 'tvSeries',
 }

--- a/src/core/database/database.module.ts
+++ b/src/core/database/database.module.ts
@@ -14,11 +14,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
         username: configService.get<string>('MYSQL_USERNAME'),
         password: configService.get<string>('MYSQL_PASSWORD'),
         database: configService.get<string>('MYSQL_DATABASE'),
-        autoLoadEntities: configService.get<boolean>(
-          'TYPEORM_AUTO_LOAD_ENTITIES',
-        ),
-        synchronize: configService.get<boolean>('TYPEORM_SYNCHRONIZE'),
-        dropSchema: process.env.NODE_ENV !== 'production',
+        autoLoadEntities: true,
       }),
     }),
   ],

--- a/src/features/content/entities/tv-series.entity.ts
+++ b/src/features/content/entities/tv-series.entity.ts
@@ -101,7 +101,7 @@ export class TvSeries extends Content {
     const series = new TvSeries();
     series.externalId = `${dto.id}`;
     series.source = SourceType.TMDB;
-    series.type = ContentType.TV;
+    series.type = ContentType.TVSERIES;
     series.updateFromDto(dto);
     return series;
   }

--- a/src/features/worker/sync.service.ts
+++ b/src/features/worker/sync.service.ts
@@ -77,7 +77,7 @@ export class SyncService {
     this.logger.log(`[TV] Starting bulk sync for ${tvSeriesIds.length} items.`);
 
     const dtos = await this.getDetailsFromApi<TvSeriesDetailDto>(
-      ContentType.TV,
+      ContentType.TVSERIES,
       tvSeriesIds,
     );
     if (dtos.length === 0) {
@@ -129,12 +129,12 @@ export class SyncService {
 
     const [movieGenres, tvGenres] = await Promise.all([
       this.tmdbApiService.fetchGenres(ContentType.MOVIE),
-      this.tmdbApiService.fetchGenres(ContentType.TV),
+      this.tmdbApiService.fetchGenres(ContentType.TVSERIES),
     ]);
 
     await Promise.all([
       processGenres(movieGenres, ContentType.MOVIE),
-      processGenres(tvGenres, ContentType.TV),
+      processGenres(tvGenres, ContentType.TVSERIES),
     ]);
     this.logger.log('✅ Genre synchronization complete.');
   }
@@ -164,7 +164,7 @@ export class SyncService {
 
     const [movieIds, tvSeriesIds] = await Promise.all([
       fetchIdsFromPages(ContentType.MOVIE),
-      fetchIdsFromPages(ContentType.TV),
+      fetchIdsFromPages(ContentType.TVSERIES),
     ]);
 
     this.logger.log(
@@ -271,7 +271,7 @@ export class SyncService {
         this.genreRepository.findBy({
           externalId: In(genreTmdbIds),
           source: SourceType.TMDB,
-          type: ContentType.TV,
+          type: ContentType.TVSERIES,
         }),
         this.tvSeasonRepository.findBy({
           externalId: In(seasonTmdbIds),

--- a/src/features/worker/task.service.ts
+++ b/src/features/worker/task.service.ts
@@ -108,7 +108,7 @@ export class TaskService implements OnModuleInit {
           endDateStr,
         ),
         this.tmdbApiService.fetchChangedIds(
-          ContentType.TV,
+          ContentType.TVSERIES,
           startDateStr,
           endDateStr,
         ),
@@ -174,7 +174,7 @@ export class TaskService implements OnModuleInit {
 
       const [popularMovieIds, popularTvSeriesIds] = await Promise.all([
         fetchAllPopularIds(ContentType.MOVIE),
-        fetchAllPopularIds(ContentType.TV),
+        fetchAllPopularIds(ContentType.TVSERIES),
       ]);
 
       this.logger.log(


### PR DESCRIPTION
## 개요

- Tv가 아니라 TvSeries로 일관성 있도록 변경했습니다.
- 스키마는 API 서버 쪽에 의존하도록 DB 설정을 변경했습니다.

## 작업사항

- TvSeries로 리팩토링을 진행했습니다.
- DB 설정에서 `autoLoadEntities: true`만 남기고 제거했습니다.