### PR TITLE
Fix: 한국어 제목 존재 여부가 올바르지 않게 저장되고 있던 것을 수정

### DIFF
--- a/src/features/content/entities/movie.entity.ts
+++ b/src/features/content/entities/movie.entity.ts
@@ -68,7 +68,7 @@ export class Movie extends Content {
       this.englishTitle = englishTranslation?.data?.title ?? null;
 
       const koreanTranslation = translations.find((t) => t.iso_639_1 === 'ko');
-      this.hasKoreanTitle = !!koreanTranslation?.data?.title;
+      this.hasKoreanTitle = !!koreanTranslation;
     } else {
       this.hasKoreanTitle = false;
     }

--- a/src/features/content/entities/tv-series.entity.ts
+++ b/src/features/content/entities/tv-series.entity.ts
@@ -85,7 +85,7 @@ export class TvSeries extends Content {
       this.englishTitle = englishTranslation?.data?.title ?? null;
 
       const koreanTranslation = translations.find((t) => t.iso_639_1 === 'ko');
-      this.hasKoreanTitle = !!koreanTranslation?.data?.title;
+      this.hasKoreanTitle = !!koreanTranslation;
     } else {
       this.hasKoreanTitle = false;
     }


### PR DESCRIPTION
## 개요

- 한국어 제목 존재 여부를 저장하는 로직이 잘못되어 있었습니다.

## 작업사항

- 한국어 제목 존재 여부가 올바르게 저장되도록 변경했습니다.